### PR TITLE
Update Slack links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ baseurl: "/ctwr_website" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: civictechwr
 github_username:  CivicTechWR
+slack_invite: "https://join.slack.com/t/civictechwr/shared_invite/zt-2hk4c93hv-DEIbxR_z1xKj8cZmayVHTw"
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
               <ul>
                 <li><a href="mailto:civictechwr@gmail.com">civictechwr@gmail.com</a></li>
                 <li><a href="https://www.meetup.com/CivicTechWR/">Join us on Meetup</a></li>
-                <li><a href="https://civictechwr.slack.com/">Join us on Slack</a></li>
+                <li><a href="{{ site.slack_invite }}">Join us on Slack</a></li>
               </ul>
             </div>
 
@@ -46,7 +46,7 @@
                 <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
                 <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
                 <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-                <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
+                <a href="{{ site.slack_invite }}"><i class="fab fa-slack"></i></a>
               </p>
             </div>
           </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
               <ul>
                 <li><a href="mailto:civictechwr@gmail.com">civictechwr@gmail.com</a></li>
                 <li><a href="https://www.meetup.com/CivicTechWR/">Join us on Meetup</a></li>
-                <li><a href="https://civictechwrslack.herokuapp.com/">Join us on Slack</a></li>
+                <li><a href="https://civictechwr.slack.com/">Join us on Slack</a></li>
               </ul>
             </div>
 
@@ -46,7 +46,7 @@
                 <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
                 <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
                 <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-                <a href="https://civictechwrslack.herokuapp.com/"><i class="fab fa-slack"></i></a>
+                <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
               </p>
             </div>
           </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
             <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
             <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
             <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-            <a href="https://civictechwrslack.herokuapp.com/"><i class="fab fa-slack"></i></a>
+            <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
           </p>
         </div>
       </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
             <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
             <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
             <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-            <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
+            <a href="{{ site.slack_invite }}"><i class="fab fa-slack"></i></a>
           </p>
         </div>
       </div>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -17,7 +17,7 @@
           <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
           <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
           <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-          <a href="https://civictechwrslack.herokuapp.com/"><i class="fab fa-slack"></i></a>
+          <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
         </p>
       </div>
     </div>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -17,7 +17,7 @@
           <a href="https://github.com/CivicTechWR"><i class="fab fa-github"></i></a>
           <a href="https://medium.com/civictechwr"><i class="fab fa-medium-m"></i></a>
           <a href="https://www.meetup.com/CivicTechWR"><i class="fab fa-meetup"></i></a>
-          <a href="https://civictechwr.slack.com/"><i class="fab fa-slack"></i></a>
+          <a href="{{ site.slack_invite }}"><i class="fab fa-slack"></i></a>
         </p>
       </div>
     </div>

--- a/get-involved.html
+++ b/get-involved.html
@@ -31,7 +31,7 @@ keywords: "civic tech, design, policy, municipal politics, technology"
 					<div class="col-md-8 col-md-offset-2 animate-box text-center">
 						<h2 class="intro-heading">Participate</h2>
 						<p>CivicTechWR brings together people from different sectors and industries to actively solve issues facing our local community. We welcome people with all types and levels of skills. Even though "tech" is in the name, everyone is welcome and everyone has a skill or experience that is valuable. You don’t need to know anything about the local government either, even though “civic” is in the name.</p>
-						<p>If you have a project idea, announcement, or event, you’re welcome to pitch at any of our hacknights, or join our <a href="https://civictechwr.slack.com/">slack team</a> to talk to the group.</p>
+						<p>If you have a project idea, announcement, or event, you’re welcome to pitch at any of our hacknights, or join our <a href="{{ site.slack_invite }}">slack team</a> to talk to the group.</p>
 					</div>
 				</div>
 			</div>

--- a/get-involved.html
+++ b/get-involved.html
@@ -31,7 +31,7 @@ keywords: "civic tech, design, policy, municipal politics, technology"
 					<div class="col-md-8 col-md-offset-2 animate-box text-center">
 						<h2 class="intro-heading">Participate</h2>
 						<p>CivicTechWR brings together people from different sectors and industries to actively solve issues facing our local community. We welcome people with all types and levels of skills. Even though "tech" is in the name, everyone is welcome and everyone has a skill or experience that is valuable. You don’t need to know anything about the local government either, even though “civic” is in the name.</p>
-						<p>If you have a project idea, announcement, or event, you’re welcome to pitch at any of our hacknights, or join our <a href="https://civictechwrslack.herokuapp.com/">slack team</a> to talk to the group.</p>
+						<p>If you have a project idea, announcement, or event, you’re welcome to pitch at any of our hacknights, or join our <a href="https://civictechwr.slack.com/">slack team</a> to talk to the group.</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Updates links to our Slack to point to https://civictechwr.slack.com/

I can't remember why, but previously we used https://civictechwrslack.herokuapp.com/